### PR TITLE
wikimedia/keyholder: add stretch support, fix key validity check

### DIFF
--- a/bin/keyholder
+++ b/bin/keyholder
@@ -41,7 +41,7 @@ is_valid_private_key() {
   chmod 0400 "$1"
   RETURN=0
   # Check that the key is a password-protected private key file.
-  /usr/bin/ssh-keygen -y -f "$1" -P "" 2>&1 | /bin/grep -q "load failed" || RETURN=1
+  /usr/bin/ssh-keygen -y -f "$1" -P "" 2>&1 | /bin/grep -Eq "load failed|incorrect passphrase" || RETURN=1
   # Restore permissions
   chmod 0$PERM "$1"
   return $RETURN


### PR DESCRIPTION
Summary:
When trying to use "keyholder arm" on netmon1002 it would not load
the RSA private key and reject it as not valid, while the same key
worked just fine on netmon1001 on jessie.

After some debugging, found out the output format of ssh-keygen changed.

Keyholder tries to ensure that it can NOT load the key without a
passphrase to make sure it has one.

It parsed for "load failed" but now the output is
"incorrect passphrase supplied to decrypt private key" so it could not
find that string and assumed we don't have a passphrase and rejected it.

This makes keyholder work on both jessie and stretch.

Originally applied via Puppet in: https://gerrit.wikimedia.org/r/#/c/358884/

Test Plan: Already applied via Puppet nearly a month ago, should be fine

Reviewers: thcipriani, Dzahn, mmodell, #release-engineering-team

Reviewed By: thcipriani, #release-engineering-team

Subscribers: Nikerabbit

Tags: #release-engineering-team

Revert Plan: Just revert it?

Differential Revision: https://phabricator.wikimedia.org/D736